### PR TITLE
Migrate from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: 
+      - master
+    tags:
+      - v*
+  pull_request:
+    branches: 
+      -master
+
+# using setup-ruby. See https://github.com/ruby/setup-ruby
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    
+    - name: Run rspec
+      run: bundle exec rspec spec
+    
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-bundler_args: --without development
-language: ruby
-sudo: false
-rvm:
-  - 2.1.9
-  - 2.2.6
-  - 2.3.1
-script: bundle exec rspec spec

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :test do
   gem 'coveralls', :require => false
-  gem 'rspec', '~> 3.5.0'
+  gem 'rspec', '~> 3.11.0'
   gem 'awesome_print'
   gem 'ruby-prof'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'coveralls', :require => false
+  gem 'simplecov',      require: false
+  gem 'simplecov-lcov', require: false
   gem 'rspec', '~> 3.11.0'
   gem 'awesome_print'
   gem 'ruby-prof'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Simple Po Parser
 
-[![Build Status](https://travis-ci.org/experteer/simple_po_parser.svg?branch=master)](https://travis-ci.org/experteer/simple_po_parser)
+[![CI](https://github.com/experteer/simple_po_parser/actions/workflows/ci.yml/badge.svg)](https://github.com/experteer/simple_po_parser/actions/workflows/ci.yml)
 [![Coverage Status](https://img.shields.io/coveralls/experteer/simple_po_parser.svg)](https://coveralls.io/github/experteer/simple_po_parser)
 [![Gem Version](https://badge.fury.io/rb/simple_po_parser.svg)](https://badge.fury.io/rb/simple_po_parser)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,17 +6,26 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require 'simplecov'
-require 'coveralls'
 require 'awesome_print'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
-  [SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter]
-  )
+SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 
 SimpleCov.start do
-    add_group "gem", "lib"
-    add_group "spec", "spec"
+  if ENV['CI']
+    require 'simplecov-lcov'
+
+    SimpleCov::Formatter::LcovFormatter.config do |c|
+      c.report_with_single_file = true
+      c.single_report_path = 'coverage/lcov.info'
+    end
+
+    formatter SimpleCov::Formatter::LcovFormatter
+  end
+  
+  add_filter "version.rb"
+
+  add_group "gem", "lib"
+  add_group "spec", "spec"
 end
 
 require 'simple_po_parser'


### PR DESCRIPTION
Free Travis CI for open source projects was discontinued. This is moving to GitHub actions as a free alternative.