### PR TITLE
gemspec: Drop unused "executables" directive

### DIFF
--- a/simple_po_parser.gemspec
+++ b/simple_po_parser.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^spec/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
This gem exposes no executables.